### PR TITLE
fix(prettier): pin prettier version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,13 +1036,13 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"peer": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
@@ -1085,9 +1085,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
 			"peer": true
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -1257,9 +1257,9 @@
 			}
 		},
 		"node_modules/@octokit/core": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.2.tgz",
-			"integrity": "sha512-cZUy1gUvd4vttMic7C0lwPed8IYXWYp8kHIMatyhY8t8n3Cpw2ILczkV5pGMPqef7v0bLo0pOHrEHarsau2Ydg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
+			"integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
 			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
@@ -2247,9 +2247,9 @@
 			}
 		},
 		"node_modules/@semantic-release/npm/node_modules/type-fest": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.9.0.tgz",
-			"integrity": "sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.1.tgz",
+			"integrity": "sha512-7ZnJYTp6uc04uYRISWtiX3DSKB/fxNQT0B5o1OUeCqiQiwF+JC9+rJiZIDrPrNCLLuTqyQmh4VdQqh/ZOkv9MQ==",
 			"engines": {
 				"node": ">=16"
 			},
@@ -2542,9 +2542,9 @@
 			}
 		},
 		"node_modules/@semantic-release/release-notes-generator/node_modules/type-fest": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.9.0.tgz",
-			"integrity": "sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.1.tgz",
+			"integrity": "sha512-7ZnJYTp6uc04uYRISWtiX3DSKB/fxNQT0B5o1OUeCqiQiwF+JC9+rJiZIDrPrNCLLuTqyQmh4VdQqh/ZOkv9MQ==",
 			"engines": {
 				"node": ">=16"
 			},
@@ -2693,16 +2693,16 @@
 			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.18.1.tgz",
-			"integrity": "sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.1.tgz",
+			"integrity": "sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==",
 			"peer": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.18.1",
-				"@typescript-eslint/type-utils": "6.18.1",
-				"@typescript-eslint/utils": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1",
+				"@typescript-eslint/scope-manager": "6.19.1",
+				"@typescript-eslint/type-utils": "6.19.1",
+				"@typescript-eslint/utils": "6.19.1",
+				"@typescript-eslint/visitor-keys": "6.19.1",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -2728,15 +2728,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.18.1.tgz",
-			"integrity": "sha512-zct/MdJnVaRRNy9e84XnVtRv9Vf91/qqe+hZJtKanjojud4wAVy/7lXxJmMyX6X6J+xc6c//YEWvpeif8cAhWA==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.1.tgz",
+			"integrity": "sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.18.1",
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/typescript-estree": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1",
+				"@typescript-eslint/scope-manager": "6.19.1",
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/typescript-estree": "6.19.1",
+				"@typescript-eslint/visitor-keys": "6.19.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2756,13 +2756,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
-			"integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
+			"integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1"
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/visitor-keys": "6.19.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2773,13 +2773,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
-			"integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.1.tgz",
+			"integrity": "sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.18.1",
-				"@typescript-eslint/utils": "6.18.1",
+				"@typescript-eslint/typescript-estree": "6.19.1",
+				"@typescript-eslint/utils": "6.19.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2800,9 +2800,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
-			"integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
+			"integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
 			"peer": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2813,13 +2813,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
-			"integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
+			"integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1",
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/visitor-keys": "6.19.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2841,17 +2841,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
-			"integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
+			"integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
 			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.18.1",
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/typescript-estree": "6.18.1",
+				"@typescript-eslint/scope-manager": "6.19.1",
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/typescript-estree": "6.19.1",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2866,12 +2866,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
-			"integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
+			"integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/types": "6.19.1",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -2909,9 +2909,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.3.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
-			"integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -11132,9 +11132,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-			"integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
+			"integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
 			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -11512,9 +11512,9 @@
 			}
 		},
 		"node_modules/rfdc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-			"integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
+			"integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
 			"peer": true
 		},
 		"node_modules/rimraf": {
@@ -11574,12 +11574,12 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-			"integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+			"integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.2.1",
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
 				"has-symbols": "^1.0.3",
 				"isarray": "^2.0.5"
 			},
@@ -11610,9 +11610,9 @@
 			]
 		},
 		"node_modules/safe-regex-test": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.1.tgz",
-			"integrity": "sha512-Y5NejJTTliTyY4H7sipGqY+RX5P87i3F7c4Rcepy72nq+mNLhIsD0W4c7kEmduMDQCSqtPsXPlSTsFhh2LQv+g==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+			"integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
 			"dependencies": {
 				"call-bind": "^1.0.5",
 				"get-intrinsic": "^1.2.2",
@@ -12089,9 +12089,9 @@
 			}
 		},
 		"node_modules/semantic-release/node_modules/type-fest": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.9.0.tgz",
-			"integrity": "sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.1.tgz",
+			"integrity": "sha512-7ZnJYTp6uc04uYRISWtiX3DSKB/fxNQT0B5o1OUeCqiQiwF+JC9+rJiZIDrPrNCLLuTqyQmh4VdQqh/ZOkv9MQ==",
 			"peer": true,
 			"engines": {
 				"node": ">=16"
@@ -12160,14 +12160,15 @@
 			"dev": true
 		},
 		"node_modules/set-function-length": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+			"integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
 			"dependencies": {
 				"define-data-property": "^1.1.1",
-				"get-intrinsic": "^1.2.1",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.2",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"has-property-descriptors": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13621,7 +13622,7 @@
 		},
 		"packages/eslint": {
 			"name": "@sngular/eslint-config",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"peerDependencies": {
 				"@typescript-eslint/eslint-plugin": "^6.0.0",
 				"@typescript-eslint/parser": "^6.0.0",
@@ -13646,7 +13647,7 @@
 			"name": "@sngular/prettier-config",
 			"version": "1.0.0",
 			"peerDependencies": {
-				"prettier": "^3.0.0"
+				"prettier": "3.2.2"
 			}
 		},
 		"packages/semantic-release": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"prepare": "husky install",
 		"prepublishOnly": "npm run types:build",
 		"release": "changeset publish",
-		"check": "npm run lint:check && npm run format:check && npm run types:check && npm test"
+		"check": "npm run lint:check && npm run format:check && npm run types:check"
 	},
 	"author": {
 		"name": "SNGULAR"

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -14,6 +14,6 @@
 	},
 	"scripts": {},
 	"peerDependencies": {
-		"prettier": "^3.0.0"
+		"prettier": "3.2.2"
 	}
 }


### PR DESCRIPTION
The version set is 3.2.2, which precedes the breaking change introduced with the parser of `.json` files.

Closes #5 